### PR TITLE
[INF-3052] Handle non 2-300 status code by erroring

### DIFF
--- a/certificates.go
+++ b/certificates.go
@@ -38,6 +38,10 @@ func (certificateClient *CertificateClient) GetById(id string) (*Certificate, er
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
+	}
+
 	certificate := &Certificate{}
 	err := json.Unmarshal([]byte(body), certificate)
 	if err != nil {
@@ -60,6 +64,10 @@ func (certificateClient *CertificateClient) Create(certificateRequest *Certifica
 
 	if r.StatusCode == 401 || r.StatusCode == 403 {
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
 	}
 
 	createdCertificate := &Certificate{}
@@ -86,6 +94,10 @@ func (certificateClient *CertificateClient) DeleteById(id string) error {
 		return fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
+	if r.StatusCode >= 400 {
+		return fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
+	}
+
 	return nil
 }
 
@@ -98,6 +110,10 @@ func (certificateClient *CertificateClient) List() (*Certificates, error) {
 
 	if r.StatusCode == 401 || r.StatusCode == 403 {
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
 	}
 
 	certificates := &Certificates{}
@@ -118,6 +134,10 @@ func (certificateClient *CertificateClient) UpdateById(id string, certificateReq
 
 	if r.StatusCode == 401 || r.StatusCode == 403 {
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
 	}
 
 	updatedCertificate := &Certificate{}

--- a/consumers.go
+++ b/consumers.go
@@ -47,6 +47,10 @@ func (consumerClient *ConsumerClient) GetById(id string) (*Consumer, error) {
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
+	}
+
 	consumer := &Consumer{}
 	err := json.Unmarshal([]byte(body), consumer)
 	if err != nil {
@@ -69,6 +73,10 @@ func (consumerClient *ConsumerClient) Create(consumerRequest *ConsumerRequest) (
 
 	if r.StatusCode == 401 || r.StatusCode == 403 {
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
 	}
 
 	createdConsumer := &Consumer{}
@@ -95,6 +103,10 @@ func (consumerClient *ConsumerClient) List() (*Consumers, error) {
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
+	}
+
 	consumers := &Consumers{}
 	err := json.Unmarshal([]byte(body), consumers)
 	if err != nil {
@@ -119,6 +131,10 @@ func (consumerClient *ConsumerClient) DeleteById(id string) error {
 		return fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
+	if r.StatusCode >= 400 {
+		return fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
+	}
+
 	return nil
 }
 
@@ -135,6 +151,10 @@ func (consumerClient *ConsumerClient) UpdateById(id string, consumerRequest *Con
 
 	if r.StatusCode == 401 || r.StatusCode == 403 {
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
 	}
 
 	updatedConsumer := &Consumer{}
@@ -159,6 +179,10 @@ func (consumerClient *ConsumerClient) CreatePluginConfig(consumerId string, plug
 
 	if r.StatusCode == 401 || r.StatusCode == 403 {
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
 	}
 
 	createdConsumerPluginConfig := &ConsumerPluginConfig{}
@@ -187,6 +211,10 @@ func (consumerClient *ConsumerClient) GetPluginConfig(consumerId string, pluginN
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
+	}
+
 	consumerPluginConfig := &ConsumerPluginConfig{}
 	err := json.Unmarshal([]byte(body), consumerPluginConfig)
 	if err != nil {
@@ -211,6 +239,10 @@ func (consumerClient *ConsumerClient) DeletePluginConfig(consumerId string, plug
 
 	if r.StatusCode == 401 || r.StatusCode == 403 {
 		return fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	if r.StatusCode >= 400 {
+		return fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
 	}
 
 	return nil

--- a/plugins.go
+++ b/plugins.go
@@ -90,6 +90,10 @@ func (pluginClient *PluginClient) List(query *PluginQueryString) ([]*Plugin, err
 			return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 		}
 
+		if r.StatusCode >= 400 {
+			return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
+		}
+
 		err := json.Unmarshal([]byte(body), data)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse plugins list response, error: %v", err)
@@ -118,6 +122,10 @@ func (pluginClient *PluginClient) Create(pluginRequest *PluginRequest) (*Plugin,
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
+	}
+
 	createdPlugin := &Plugin{}
 	err := json.Unmarshal([]byte(body), createdPlugin)
 	if err != nil {
@@ -140,6 +148,10 @@ func (pluginClient *PluginClient) UpdateById(id string, pluginRequest *PluginReq
 
 	if r.StatusCode == 401 || r.StatusCode == 403 {
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
 	}
 
 	updatedPlugin := &Plugin{}
@@ -166,6 +178,10 @@ func (pluginClient *PluginClient) DeleteById(id string) error {
 		return fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
+	if r.StatusCode >= 400 {
+		return fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
+	}
+
 	return nil
 }
 
@@ -177,6 +193,10 @@ func (pluginClient *PluginClient) GetByConsumerId(id string) (*Plugins, error) {
 
 	if r.StatusCode == 401 || r.StatusCode == 403 {
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
 	}
 
 	plugins := &Plugins{}
@@ -198,6 +218,10 @@ func (pluginClient *PluginClient) GetByRouteId(id string) (*Plugins, error) {
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
+	}
+
 	plugins := &Plugins{}
 	err := json.Unmarshal([]byte(body), plugins)
 	if err != nil {
@@ -215,6 +239,10 @@ func (pluginClient *PluginClient) GetByServiceId(id string) (*Plugins, error) {
 
 	if r.StatusCode == 401 || r.StatusCode == 403 {
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
 	}
 
 	plugins := &Plugins{}

--- a/routes.go
+++ b/routes.go
@@ -74,6 +74,11 @@ func (routeClient *RouteClient) GetById(id string) (*Route, error) {
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
+	if r.StatusCode > 400 {
+
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
+	}
+
 	route := &Route{}
 	err := json.Unmarshal([]byte(body), route)
 	if err != nil {
@@ -95,6 +100,10 @@ func (routeClient *RouteClient) Create(routeRequest *RouteRequest) (*Route, erro
 
 	if r.StatusCode == 401 || r.StatusCode == 403 {
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
 	}
 
 	createdRoute := &Route{}
@@ -133,6 +142,10 @@ func (routeClient *RouteClient) List(query *RouteQueryString) ([]*Route, error) 
 			return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 		}
 
+		if r.StatusCode >= 400 {
+			return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
+		}
+
 		err := json.Unmarshal([]byte(body), data)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse route get response, error: %v", err)
@@ -168,6 +181,10 @@ func (routeClient *RouteClient) GetRoutesFromServiceId(id string) ([]*Route, err
 			return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 		}
 
+		if r.StatusCode >= 400 {
+			return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
+		}
+
 		err := json.Unmarshal([]byte(body), data)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse route get response, error: %v", err)
@@ -197,6 +214,10 @@ func (routeClient *RouteClient) UpdateById(id string, routeRequest *RouteRequest
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
+	}
+
 	updatedRoute := &Route{}
 	err := json.Unmarshal([]byte(body), updatedRoute)
 	if err != nil {
@@ -222,6 +243,10 @@ func (routeClient *RouteClient) DeleteById(id string) error {
 
 	if r.StatusCode == 401 || r.StatusCode == 403 {
 		return fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	if r.StatusCode >= 400 {
+		return fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
 	}
 
 	return nil

--- a/services.go
+++ b/services.go
@@ -117,6 +117,11 @@ func (serviceClient *ServiceClient) getService(endpoint string) (*Service, error
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
+	if r.StatusCode >= 400 {
+
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
+	}
+
 	service := &Service{}
 	err := json.Unmarshal([]byte(body), service)
 	if err != nil {
@@ -151,6 +156,11 @@ func (serviceClient *ServiceClient) GetServices(query *ServiceQueryString) ([]*S
 
 		if r.StatusCode == 401 || r.StatusCode == 403 {
 			return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+		}
+
+		if r.StatusCode >= 400 {
+
+			return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
 		}
 
 		err := json.Unmarshal([]byte(body), data)
@@ -192,6 +202,10 @@ func (serviceClient *ServiceClient) updateService(endpoint string, serviceReques
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
+	}
+
 	updatedService := &Service{}
 	err := json.Unmarshal([]byte(body), updatedService)
 	if err != nil {
@@ -217,6 +231,10 @@ func (serviceClient *ServiceClient) DeleteServiceById(id string) error {
 
 	if r.StatusCode == 401 || r.StatusCode == 403 {
 		return fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	if r.StatusCode >= 400 {
+		return fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
 	}
 
 	return nil

--- a/snis.go
+++ b/snis.go
@@ -37,6 +37,10 @@ func (snisClient *SnisClient) Create(snisRequest *SnisRequest) (*Sni, error) {
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
+	}
+
 	sni := &Sni{}
 	err := json.Unmarshal([]byte(body), sni)
 	if err != nil {
@@ -59,6 +63,10 @@ func (snisClient *SnisClient) GetByName(name string) (*Sni, error) {
 
 	if r.StatusCode == 401 || r.StatusCode == 403 {
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
 	}
 
 	sni := &Sni{}
@@ -85,6 +93,10 @@ func (snisClient *SnisClient) List() (*Snis, error) {
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
+	}
+
 	snis := &Snis{}
 	err := json.Unmarshal([]byte(body), snis)
 	if err != nil {
@@ -105,6 +117,10 @@ func (snisClient *SnisClient) DeleteByName(name string) error {
 		return fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
+	if r.StatusCode >= 400 {
+		return fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
+	}
+
 	return nil
 }
 
@@ -117,6 +133,10 @@ func (snisClient *SnisClient) UpdateByName(name string, snisRequest *SnisRequest
 
 	if r.StatusCode == 401 || r.StatusCode == 403 {
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
 	}
 
 	updatedSni := &Sni{}

--- a/targets.go
+++ b/targets.go
@@ -46,6 +46,10 @@ func (targetClient *TargetClient) CreateFromUpstreamId(id string, targetRequest 
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
+	if r.StatusCode > 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
+	}
+
 	createdTarget := &Target{}
 	err := json.Unmarshal([]byte(body), createdTarget)
 	if err != nil {
@@ -79,6 +83,10 @@ func (targetClient *TargetClient) GetTargetsFromUpstreamId(id string) ([]*Target
 
 		if r.StatusCode == 404 {
 			return nil, fmt.Errorf("non existent upstream: %s", id)
+		}
+
+		if r.StatusCode >= 400 {
+			return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
 		}
 
 		err := json.Unmarshal([]byte(body), data)
@@ -178,6 +186,10 @@ func (targetClient *TargetClient) GetTargetsWithHealthFromUpstreamId(id string) 
 
 		if r.StatusCode == 404 {
 			return nil, fmt.Errorf("non existent upstream: %s", id)
+		}
+
+		if r.StatusCode >= 400 {
+			return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
 		}
 
 		err := json.Unmarshal([]byte(body), data)

--- a/upstreams.go
+++ b/upstreams.go
@@ -96,6 +96,10 @@ func (upstreamClient *UpstreamClient) GetById(id string) (*Upstream, error) {
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
+	}
+
 	upstream := &Upstream{}
 	err := json.Unmarshal([]byte(body), upstream)
 	if err != nil {
@@ -118,6 +122,10 @@ func (upstreamClient *UpstreamClient) Create(upstreamRequest *UpstreamRequest) (
 
 	if r.StatusCode == 401 || r.StatusCode == 403 {
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
 	}
 
 	createdUpstream := &Upstream{}
@@ -148,6 +156,10 @@ func (upstreamClient *UpstreamClient) DeleteById(id string) error {
 		return fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
+	if r.StatusCode >= 400 {
+		return fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
+	}
+
 	return nil
 }
 
@@ -160,6 +172,10 @@ func (upstreamClient *UpstreamClient) List() (*Upstreams, error) {
 
 	if r.StatusCode == 401 || r.StatusCode == 403 {
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
 	}
 
 	upstreams := &Upstreams{}
@@ -184,6 +200,10 @@ func (upstreamClient *UpstreamClient) UpdateById(id string, upstreamRequest *Ups
 
 	if r.StatusCode == 401 || r.StatusCode == 403 {
 		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	if r.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected response from kong. Status code %d, message: %s", r.StatusCode, body)
 	}
 
 	updatedUpstream := &Upstream{}


### PR DESCRIPTION
Context: https://datacamp.slack.com/archives/C054Q1E9DRB/p1682417011903839

This also reverts the changes in `a76dc2fad87b27eb9d599a22b01026e90b151438`, since the current version of this library in the kong terraform provider is built off `305470f01f9a2e2d049b718796716825369d4469` (the commit before `a76dc2...`). **Edit**: Ignore the above, we are now also including `a76dc2...` as it has some nice typo fixes.

Testing:
I span up a local k8s cluster and installed kong using the same image we're using in production. Using the existing terraform provider, I created a few hundred dummy routes and services.
I then ran a reverse proxy that would forward all requests to kong but add a 500 error to the responses. Next, I added this repo as a submodule to the kong terraform provider, rebuilt the provider, and added it to `~/.terraform.d/plugins/terraform.local/local/kong/1.0.2/darwin_arm64/terraform-provider-kong_v1.0.2`. This then allowed me to use it in a local terraform setup as 
```
terraform {
  required_providers {
    kong = {
      source  = "terraform.local/local/kong"
      version = "1.0.2"
    }
  }
  required_version = ">= 1.1"
}
```
I then repointed my kong provider config at the 500-adding reverse proxy and saw the following results when running `terraform plan`:
```
╷
│ Error: could not find kong service: unexpected response from kong. Status code 500, message: {"updated_at":1682421106,"connect_timeout":1000,"read_timeout":3000,"protocol":"http","tags":null,"host":"test.org","id":"48e839d6-d557-4a46-99c3-93e89362abdf","retries":5,"tls_verify":null,"name":"test-55","path":"/mypath","tls_verify_depth":null,"client_certificate":null,"ca_certificates":null,"write_timeout":2000,"port":8080,"created_at":1682420899}
│
│   with kong_service.service[55],
│   on main.tf line 16, in resource "kong_service" "service":
│   16: resource "kong_service" "service" {
│
╵
```

