### PR TITLE
[INF-4105] bugfix consumer

### DIFF
--- a/consumers.go
+++ b/consumers.go
@@ -173,7 +173,7 @@ func (consumerClient *ConsumerClient) UpdateById(id string, consumerRequest *Con
 	return updatedConsumer, nil
 }
 
-func (consumerClient *ConsumerClient) CreatePluginConfig(consumerId string, pluginName string, pluginConfig string) (*ConsumerPluginConfig, error) {
+func (consumerClient *ConsumerClient) CreatePluginConfig(consumerId string, pluginName string, pluginConfig string, tags []*string) (*ConsumerPluginConfig, error) {
 	r, body, errs := newPost(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+consumerId+"/"+pluginName).Send(pluginConfig).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not configure plugin for consumer, error: %v", errs)

--- a/consumers.go
+++ b/consumers.go
@@ -173,7 +173,7 @@ func (consumerClient *ConsumerClient) UpdateById(id string, consumerRequest *Con
 	return updatedConsumer, nil
 }
 
-func (consumerClient *ConsumerClient) CreatePluginConfig(consumerId string, pluginName string, pluginConfig string, tags []*string) (*ConsumerPluginConfig, error) {
+func (consumerClient *ConsumerClient) CreatePluginConfig(consumerId string, pluginName string, pluginConfig string) (*ConsumerPluginConfig, error) {
 	r, body, errs := newPost(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+consumerId+"/"+pluginName).Send(pluginConfig).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not configure plugin for consumer, error: %v", errs)

--- a/consumers.go
+++ b/consumers.go
@@ -30,7 +30,6 @@ type Consumers struct {
 type ConsumerPluginConfig struct {
 	Id   string `json:"id,omitempty" yaml:"id,omitempty"`
 	Body string
-	Tags []*string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 const ConsumersPath = "/consumers/"

--- a/consumers.go
+++ b/consumers.go
@@ -174,18 +174,7 @@ func (consumerClient *ConsumerClient) UpdateById(id string, consumerRequest *Con
 }
 
 func (consumerClient *ConsumerClient) CreatePluginConfig(consumerId string, pluginName string, pluginConfig string, tags []*string) (*ConsumerPluginConfig, error) {
-	requestBody := map[string]interface{}{
-		"config": pluginConfig,
-	}
-
-	// Add tags only if they are provided
-	if tags != nil {
-		requestBody["tags"] = tags
-	}
-
-	r, body, errs := newPost(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+consumerId+"/"+pluginName).
-		Send(requestBody).
-		End()
+	r, body, errs := newPost(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+consumerId+"/"+pluginName).Send(pluginConfig).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not configure plugin for consumer, error: %v", errs)
 	}


### PR DESCRIPTION
Revert the split up off the body creation as this was causing a bug that made the body not parse properly.
Error logs and context: https://datacamp.slack.com/archives/C023NTN0N3F/p1738667967469959

Removal of tags in the struct off ConsumerPluginConfig as no tags need to created there. When tags are in the struct the terraform plan will keep recreating the kong_consumer_plugin_config for consumer_acl_config. Test cases:
* https://concourse.ops.datacamp.com/teams/developer-tooling/pipelines/test/jobs/deploy%20test%20in%20staging/builds/622
*https://concourse.ops.datacamp.com/teams/developer-tooling/pipelines/test/jobs/deploy%20test%20in%20staging/builds/623
*https://concourse.ops.datacamp.com/teams/developer-tooling/pipelines/test/jobs/deploy%20test%20in%20staging/builds/626
*https://concourse.ops.datacamp.com/teams/developer-tooling/pipelines/test/jobs/deploy%20test%20in%20staging/builds/626.1

On the last job(626) The tag is removed properly from the state and in 626.1 it's no longer recreated
